### PR TITLE
Change name to common templates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "govuk-prototype-kit-templates",
+  "name": "@govuk-prototype-kit/common-templates",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "govuk-prototype-kit-templates",
+      "name": "@govuk-prototype-kit/common-templates",
       "version": "1.0.0",
       "license": "MIT"
     }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "@govuk-prototype-kit/templates",
+  "name": "@govuk-prototype-kit/common-templates",
   "version": "1.0.0",
   "description": "Common service page templates for the GOV.UK Prototype Kit",
   "author": "GOV.UK Prototype team, UK Government Digital Service",
   "license": "MIT",
-  "homepage": "https://github.com/alphagov/govuk-prototype-kit-templates",
+  "homepage": "https://github.com/alphagov/govuk-prototype-kit-common-templates",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alphagov/govuk-prototype-kit-templates.git"
+    "url": "https://github.com/alphagov/govuk-prototype-kit-common-templates.git"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
the previous name 'templates' was confusing in context, as the Templates page had h1 Templates and then h2 Templates for this group. This PR makes the name more specific