### PR TITLE
Preparing for release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Unreleased
 
+## 1.1.0
+
 ### Fixes
 
- - [#11 - Use Nunjucks for all components, improve HTML formatting](https://github.com/alphagov/govuk-prototype-kit-common-templates/pull/11)
+- [#11 - Use Nunjucks for all components, improve HTML formatting](https://github.com/alphagov/govuk-prototype-kit-common-templates/pull/11)
 
 - [#6 Improve check answers](https://github.com/alphagov/govuk-prototype-kit-common-templates/pull/6/files)  
 Use nunjucks instead of html.  
@@ -15,5 +17,6 @@ Use a simpler list, not 2 lists with headings.
 Simplifies the placeholder text.  
 Uses 'path' instead of 'url'.
 
+## 1.0.0
 
 Create plugin

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-prototype-kit/common-templates",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-prototype-kit/common-templates",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-prototype-kit/common-templates",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Common service page templates for the GOV.UK Prototype Kit",
   "author": "GOV.UK Prototype team, UK Government Digital Service",
   "license": "MIT",


### PR DESCRIPTION
- [#11 - Use Nunjucks for all components, improve HTML formatting](https://github.com/alphagov/govuk-prototype-kit-common-templates/pull/11)

- [#6 Improve check answers](https://github.com/alphagov/govuk-prototype-kit-common-templates/pull/6/files)  
Use nunjucks instead of html.  
Make the placeholder data easier to understand.  
Use a simpler list, not 2 lists with headings.

- [#7: Update question page](https://github.com/alphagov/govuk-prototype-kit-common-templates/pull/7)  
Simplifies the placeholder text.  
Uses 'path' instead of 'url'.