### PR TITLE
Preparing for release 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.1.1
+
 ### Fixes
 
 - [#14 - Remove pagination scss from plug-in config as the file has been removed](https://github.com/alphagov/govuk-prototype-kit-common-templates/pull/14)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-prototype-kit/common-templates",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-prototype-kit/common-templates",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-prototype-kit/common-templates",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Common service page templates for the GOV.UK Prototype Kit",
   "author": "GOV.UK Prototype team, UK Government Digital Service",
   "license": "MIT",


### PR DESCRIPTION
- [#14 - Remove pagination scss from plug-in config as the file has been removed](https://github.com/alphagov/govuk-prototype-kit-common-templates/pull/14)