### PR TITLE
Release v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 1.2.1
+
+### Fixes
+
+- [#21 - Using earliest supported version for plugin dependency](https://github.com/alphagov/govuk-prototype-kit-common-templates/pull/21)
+
 ## 1.2.0
 
 ### New features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-prototype-kit/common-templates",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-prototype-kit/common-templates",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-prototype-kit/common-templates",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Common service page templates for the GOV.UK Prototype Kit",
   "author": "GOV.UK Prototype team, UK Government Digital Service",
   "license": "MIT",


### PR DESCRIPTION
### Fixes

- [#21 - Using earliest supported version for plugin dependency](https://github.com/alphagov/govuk-prototype-kit-common-templates/pull/21)