### PR TITLE
Add task list page template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [#26 - Add task list page template](https://github.com/alphagov/govuk-prototype-kit-common-templates/pull/26)
+
 ## 1.2.2
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.0.0
 
 - [#26 - Add task list page template](https://github.com/alphagov/govuk-prototype-kit-common-templates/pull/26)
 

--- a/govuk-prototype-kit.config.json
+++ b/govuk-prototype-kit.config.json
@@ -7,7 +7,7 @@
   },
   "pluginDependencies": [{
     "packageName": "govuk-frontend",
-    "minVersion": "4.4.0"
+    "minVersion": "5.0.0"
   }],
   "sass": [
     "/sass/_contents-list.scss",
@@ -53,6 +53,11 @@
     {
       "name": "Mainstream guide page",
       "path": "/templates/mainstream-guide.html",
+      "type":  "nunjucks"
+    },
+    {
+      "name": "Task list page",
+      "path": "/templates/task-list.html",
       "type":  "nunjucks"
     }]
 }

--- a/govuk-prototype-kit.config.json
+++ b/govuk-prototype-kit.config.json
@@ -56,7 +56,7 @@
       "type":  "nunjucks"
     },
     {
-      "name": "Task list page",
+      "name": "Task list page (for GOV.UK Frontend >=5.0.0)",
       "path": "/templates/task-list.html",
       "type":  "nunjucks"
     }]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-prototype-kit/common-templates",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-prototype-kit/common-templates",
-      "version": "1.2.2",
+      "version": "2.0.0",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-prototype-kit/common-templates",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Common service page templates for the GOV.UK Prototype Kit",
   "author": "GOV.UK Prototype team, UK Government Digital Service",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-prototype-kit/common-templates",
-  "version": "2.0.0",
+  "version": "1.2.2",
   "description": "Common service page templates for the GOV.UK Prototype Kit",
   "author": "GOV.UK Prototype team, UK Government Digital Service",
   "license": "MIT",

--- a/templates/task-list.html
+++ b/templates/task-list.html
@@ -24,7 +24,7 @@
         classes: "govuk-tag--blue"
       } %}
 
-      {% To switch between the completed and incomplete statues, use some inline logic within the component below, like this: "status: (completedStatus if ... else incompleteStatus)" %}
+      {# To switch between the completed and incomplete statues, use some inline logic within the component below, like this: "status: (completedStatus if ... else incompleteStatus)" #}
 
       {{ govukTaskList({
         idPrefix: "first-section",

--- a/templates/task-list.html
+++ b/templates/task-list.html
@@ -30,24 +30,21 @@
         idPrefix: "first-section",
         items: [
           {
-            title:
-              {
-                text: "Name of first task"
-              },
+            title: {
+              text: "Name of first task"
+            },
             href: "#",
             status: completedStatus
           },
           {
-            title:
-              {
-                text: "Name of second task"
-              },
+            title: {
+              text: "Name of second task"
+            },
             href: "#",
             status: incompleteStatus
           }
         ]
-      })
-      }}
+      }) }}
 
       <h2 class="govuk-heading-m govuk-!-margin-top-5">[ Heading for second set of tasks ]</h2>
 
@@ -55,48 +52,42 @@
         idPrefix: "second-section",
         items: [
           {
-            title:
-              {
-                text: "Name of third task"
-              },
+            title: {
+              text: "Name of third task"
+            },
             href: "#",
             status: completedStatus
           },
           {
-            title:
-              {
-                text: "Name of fifth task"
-              },
+            title: {
+              text: "Name of fifth task"
+            },
             href: "#",
             status: incompleteStatus
           },
           {
-            title:
-              {
-                text: "Name of sixth task"
-              },
+            title: {
+              text: "Name of sixth task"
+            },
             href: "#",
             status: completedStatus
           },
           {
-            title:
-              {
-                text: "Name of seventh task"
-              },
+            title: {
+              text: "Name of seventh task"
+            },
             href: "#",
             status: incompleteStatus
           },
           {
-            title:
-              {
-                text: "Name of eighth task"
-              },
+            title: {
+              text: "Name of eighth task"
+            },
             href: "#",
             status: incompleteStatus
           }
         ]
-      })
-      }}
+      }) }}
 
       <div class="govuk-!-margin-top-5">
         {{ govukButton({ text: "Apply", href: "#" }) }}

--- a/templates/task-list.html
+++ b/templates/task-list.html
@@ -1,0 +1,107 @@
+{% extends "layouts/main.html" %}
+
+{% block pageTitle %}
+  Task list template – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">{{ serviceName }}</h1>
+
+      <h2 class="govuk-heading-m">[ Heading for first set of tasks ]</h2>
+
+      {% set completedStatus = {
+        text: "Completed"
+      } %}
+
+      {% set incompleteStatus = {
+        text: "Incomplete",
+        classes: "govuk-tag--blue"
+      } %}
+
+      {% To switch between the completed and incomplete statues, use some inline logic within the component below, like this: "status: (completedStatus if ... else incompleteStatus)" %}
+
+      {{ govukTaskList({
+        idPrefix: "first-section",
+        items: [
+          {
+            title:
+              {
+                text: "Name of first task"
+              },
+            href: "#",
+            status: completedStatus
+          },
+          {
+            title:
+              {
+                text: "Name of second task"
+              },
+            href: "#",
+            status: incompleteStatus
+          }
+        ]
+      })
+      }}
+
+      <h2 class="govuk-heading-m govuk-!-margin-top-5">[ Heading for second set of tasks ]</h2>
+
+      {{ govukTaskList({
+        idPrefix: "second-section",
+        items: [
+          {
+            title:
+              {
+                text: "Name of third task"
+              },
+            href: "#",
+            status: completedStatus
+          },
+          {
+            title:
+              {
+                text: "Name of fifth task"
+              },
+            href: "#",
+            status: incompleteStatus
+          },
+          {
+            title:
+              {
+                text: "Name of sixth task"
+              },
+            href: "#",
+            status: completedStatus
+          },
+          {
+            title:
+              {
+                text: "Name of seventh task"
+              },
+            href: "#",
+            status: incompleteStatus
+          },
+          {
+            title:
+              {
+                text: "Name of eighth task"
+              },
+            href: "#",
+            status: incompleteStatus
+          }
+        ]
+      })
+      }}
+
+      <div class="govuk-!-margin-top-5">
+        {{ govukButton({ text: "Apply", href: "#" }) }}
+      </div>
+
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
This adds a Task list page to the common templates plugin, to make it easier for people to prototype task lists using the GOV.UK Prototype Kit.

See [Decide what to do with the Prototype Kit Task List plugin](https://github.com/alphagov/govuk-design-system/issues/3150).