### PR TITLE
Support GOV.UK Frontend 6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking changes
+
+- [#33 - Support GOV.UK Frontend 6.0](https://github.com/alphagov/govuk-prototype-kit-common-templates/pull/33)
+
 ## 2.0.1
 
 - [#28 - Fix the task list template to use the correct status tag options](https://github.com/alphagov/govuk-prototype-kit-common-templates/pull/28)

--- a/govuk-prototype-kit.config.json
+++ b/govuk-prototype-kit.config.json
@@ -7,7 +7,7 @@
   },
   "pluginDependencies": [{
     "packageName": "govuk-frontend",
-    "minVersion": "5.0.0"
+    "minVersion": "6.0.0"
   }],
   "sass": [
     "/sass/_contents-list.scss",

--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependencies": {
+    "govuk-frontend": ">=6.0.0"
   }
 }

--- a/templates/check-answers.html
+++ b/templates/check-answers.html
@@ -4,7 +4,7 @@
   Check your answers template – {{ serviceName }} – GOV.UK Prototype Kit
 {% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: "javascript:window.history.back()"

--- a/templates/content.html
+++ b/templates/content.html
@@ -4,7 +4,7 @@
   Content page template – {{ serviceName }} – GOV.UK Prototype Kit
 {% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: "javascript:window.history.back()"

--- a/templates/mainstream-guide.html
+++ b/templates/mainstream-guide.html
@@ -4,9 +4,11 @@
   Mainstream guide example
 {% endblock %}
 
+{# Blank header with no service name for this page #}
 {% block header %}
-  <!-- Blank header with no service name for this page -->
-  {{ govukHeader() }}
+  <header>
+    {{govukHeader()}}
+  </header>
 {% endblock %}
 
 {% block containerStart %}

--- a/templates/mainstream-guide.html
+++ b/templates/mainstream-guide.html
@@ -9,8 +9,7 @@
   {{ govukHeader() }}
 {% endblock %}
 
-{% block beforeContent %}
-
+{% block containerStart %}
   {{ govukBreadcrumbs({
     items: [
       {
@@ -26,7 +25,6 @@
       }
     ]
   }) }}
-
 {% endblock %}
 
 {% block content %}

--- a/templates/question.html
+++ b/templates/question.html
@@ -4,11 +4,11 @@
   Question page template – {{ serviceName }} – GOV.UK Prototype Kit
 {% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
-  text: "Back",
-  href: "javascript:window.history.back()"
-}) }}
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
 {% endblock %}
 
 {% block content %}

--- a/templates/start.html
+++ b/templates/start.html
@@ -5,8 +5,9 @@
 {% endblock %}
 
 {% block header %}
-  <!-- Blank header with no service name for the start page -->
-  {{ govukHeader() }}
+  <header>
+    {{govukHeader()}}
+  </header>
 {% endblock %}
 
 {% block containerStart %}

--- a/templates/start.html
+++ b/templates/start.html
@@ -9,8 +9,7 @@
   {{ govukHeader() }}
 {% endblock %}
 
-{% block beforeContent %}
-
+{% block containerStart %}
   {{ govukBreadcrumbs({
     items: [
       {
@@ -26,7 +25,6 @@
       }
     ]
   }) }}
-
 {% endblock %}
 
 {% block content %}

--- a/templates/task-list.html
+++ b/templates/task-list.html
@@ -4,8 +4,7 @@
   Task list template – {{ serviceName }} – GOV.UK Prototype Kit
 {% endblock %}
 
-{% block beforeContent %}
-{% endblock %}
+{% block containerStart %}{% endblock %}
 
 {% block content %}
   <div class="govuk-grid-row">


### PR DESCRIPTION
Implement support for GOV.UK Frontend 6.0 by:
- using the correct `containerStart` block when available (it takes precedence over the deprecated `beforeContent` block when both are defined)
- ensuring a `<header>` tag wraps the `govukHeader` on the `start` and `mainstream-guide` templates.

As templates will be copied in user's prototype, this is implemented as a breaking change to keep the code of the template as easy to understand as possible. To reflect this:
- the Prototype Kit config advertises a minimum version of 6.0.0 for GOV.UK Frontend
- a `peerDependencies` entry has been added to the `package.json` to prevent installation with earlier versions of GOV.UK Frontend.

## Testing

To test the changes locally, you'll need:
- [optionally] a local clone of this repository, on the `support-govuk-frontend-6.0` branch 
- a prototype running the upcoming version of the Prototype Kit (clone the prototype kit, from the folder run `npx . create --version local-symlink <OTHER_FOLDER_OF_CHOICE>`)

### Against the upcoming version of the Prototype Kit

For the folder of the prototype running the upcoming version:
1. Install this branch of the common templates package (`npm install github:alphagov/govuk-prototype-kit-common-templates#support-govuk-frontend-6.0`) or use `npm link` if you've cloned the repository
2. Install GOV.UK Frontend v6.0.0 `npm install govuk-frontend@next`
6. [Optional] If you had used `npm link` to a local clone of common templates, use `npm link` again as this'll have been wiped out by the `npm install`
7. Head to the page for managing templates (http://localhost:3000/manage-prototype/templates)
8. Use `View` to check each template renders correctly, particularly:
	- Breadcrumbs or back buttons are displayed correctly
	- On "Start" and "Mainstream guide", a `<header>` element is present